### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ Assumptions for the project:
   5) The priority of any given process can range from 1 to 100 where a higher number implies a higher priority.  
     a) If a process is created, by the user or randomly, with priority, initial priority ranges from 0 to 20.
   6) If there are two processes with the same priority, the one which gets executed first is the one with the shortest burst time (see Assumption #7). 
-  7) If two processes has the same burst time, then the processes are chosen at random and thereafter executed. 
+  7) If two processes has the same burst time, then the process with the lowest ID number gets executed first. 


### PR DESCRIPTION
I modified Assumption 7 to state that, if two processes have exactly the same burst time, then the one which is executed first will be the one with the lowest ID number. My FCFS and SJF algorithms still obtain the correct values for the average wait time and the average turnaround time, so changing this assumption should not effect any of the others whatsoever and permit my code to be consistent with every assumption (including this new one!).